### PR TITLE
Upgrade project to use ocamlformat.0.26.1

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Updated .ocamlformat to use the latest version
+commit hash: a6a668fc2780307116001f76b07a3f1a1be02592

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
-# Updated .ocamlformat to use the latest version
-commit hash: a6a668fc2780307116001f76b07a3f1a1be02592
+# The commit upgrading to ocamlformat 0.26.1
+a6a668fc2780307116001f76b07a3f1a1be02592

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version=0.18.0
+version=0.26.1

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -32,7 +32,5 @@ let info =
     ~doc:"List API changes between two versions of a library"
 
 let term = Cmdliner.Term.(const run $ ref_cmi $ current_cmi)
-
 let main = Cmdliner.Cmd.v info term
-
 let () = Stdlib.exit @@ Cmdliner.Cmd.eval main


### PR DESCRIPTION
Here are the changes of this pull request. @NathanReb 
1. Updated the programs current ocamlformat from `ocamlformat.0.18.0` to `ocamlformat.0.26.1` which is the latest version.
2. Run `dune build @fmt --auto-promote` to apply formating on the changes and made sure ocamlformat runs with no error. The `bin/api_diff.ml` file contains correct formatting.