### PR TITLE
Relax ocaml constraint to any 4.14 patch

### DIFF
--- a/api-watch.opam
+++ b/api-watch.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/NathanReb/ocaml-api-watch"
 bug-reports: "https://github.com/NathanReb/ocaml-api-watch/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.12.0" & < "4.13.0"}
+  "ocaml" {>= "4.14.0" & < "5.0.0"}
   "logs"
   "cmdliner" {>= "1.1.0"}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -15,6 +15,6 @@
  (name api-watch)
  (synopsis "Libraries and tools to keep watch on your OCaml lib's API changes")
  (depends
-  (ocaml (and (>= 4.12.0) (< 4.13.0)))
+  (ocaml (and (>= 4.14.0) (< 5.0.0)))
   logs
   (cmdliner (>= 1.1.0))))


### PR DESCRIPTION
The changes upgrades the version to OCaml version 4.14

1. I updated `dune project` to reflect the constraints of the new version needed, ran `dune build api-watch.opam` and the opam file updated accordingly.
2. I installed the OCaml version 4.14.1 to run the builds with. The files had no breaking changes to the compiler libraries we were using between 4.12 and 4.14.
