### PR TITLE
Update to remove install error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ cd ocaml-api-watch
 And setup a local opam switch to install the right ocaml version along with the
 set of base dependencies:
 ```
-opam switch create ./ 4.12.1 --deps-only -t
+opam switch create ./ 4.14.0 --deps-only -t
 ```
 
 You should also install `ocamlformat` and `merlin` for a better dev experience

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ cd ocaml-api-watch
 And setup a local opam switch to install the right ocaml version along with the
 set of base dependencies:
 ```
-opam switch create ./ 4.14.0 --deps-only -t
+opam switch create ./ --deps-only -t
 ```
 
 You should also install `ocamlformat` and `merlin` for a better dev experience


### PR DESCRIPTION
Hello! I'm an outreachy applicant. 

While following the instructions in CONTRIBUTING.md I got the following error:
```
Switch invariant: ["ocaml-base-compiler" {= "4.12.1"} | "ocaml-system" {= "4.12.1"}]
[ERROR] Could not determine which packages to install for this switch:
  * No agreement on the version of ocaml:
    - (invariant) → ocaml-base-compiler = 4.12.1 → ocaml = 4.12.1
    - api-watch → ocaml >= 4.14.0
    You can temporarily relax the switch invariant with `--update-invariant'
```

Which I resolved by making the change in the PR to my install. Would this change be correct for the install instructions to be working for others as well?