### PR TITLE
Add cram tests for diffing changes to types

### DIFF
--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -64,7 +64,8 @@ We generate the .cmi file
 
 Run api-watcher on the two cmi files, there should be a difference
 
-The api-diff tool fails to detect this particular change and should be fixed!
+TODO: The api-diff tool fails to detect this particular change and should be fixed!
+See https://github.com/NathanReb/ocaml-api-watch/issues/23
 
   $ api-diff ref.cmi remove_type.cmi
   API unchanged!

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -15,7 +15,7 @@ Here we generate a basic `.mli` file with a type and a function:
 
   $ cat > ref.mli << EOF
   > type t = int
-  > 
+  > type unused_type = string
   > val f : t -> string
   > EOF
 
@@ -37,10 +37,11 @@ Here we generate a basic `.mli` files with two types and a function:
 
   $ cat > add_type.mli <<EOF
   > type t = int
+  > type unused_type = string
   > type added_t = float
   > val f : t -> string
   > EOF
- 
+
 We generate the .cmi file
 
   $ ocamlc add_type.mli
@@ -56,6 +57,8 @@ Now we run api-watcher on the two cmi files, there should be a difference:
 ### A file with a removed type:
 
   $ cat > remove_type.mli <<EOF
+  > type t = int
+  > val f : t -> string
   > EOF
 
 We generate the .cmi file
@@ -65,12 +68,16 @@ We generate the .cmi file
 Now we run api-watcher on the two cmi files, there should be a difference:
 
   $ api-diff ref.cmi remove_type.cmi
-  API changed!
+  api-watcher: internal error, uncaught exception:
+               Includemod.Error(_)
+               
+  [125]
 
 ### A file with a modified type:
 
   $ cat > modify_type.mli <<EOF
   > type t = float
+  > type unused_type = string
   > val f : t -> string
   > EOF
 

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -11,8 +11,6 @@ and simply generate a modified version of it.
 
 ## Identical .cmi files:
 
-Here we generate a basic `.mli` file with a type and a function:
-
   $ cat > ref.mli << EOF
   > type t = int
   > type unused_type = string

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -62,11 +62,8 @@ We generate the .cmi file
 
 Run api-watcher on the two cmi files, there should be a difference
 
-TODO: The api-diff tool fails to detect this particular change and should be fixed!
-See https://github.com/NathanReb/ocaml-api-watch/issues/23
-
   $ api-diff ref.cmi remove_type.cmi
-  API unchanged!
+  API changed!
 
 ### A file with a modified type:
 

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -28,3 +28,54 @@ there should be no diff:
 
   $ api-diff ref.cmi ref.cmi
   API unchanged!
+
+## Different .cmi files for type test:
+
+Here we generate a basic `.mli` files with two types and a function:
+
+### A file with an additional type:
+
+  $ cat > add_type.mli << EOF
+  > type t = int
+  > type added_t = float
+  > val f : t -> string
+  > EOF 
+
+We generate the .cmi file
+
+  $ ocamlc add_type.mli
+
+Now we run api-watcher on the two cmi files, there should be a difference:
+
+  $ api-diff ref.cmi add_type.cmi
+  API changed!
+
+### A file with a removed type:
+
+  $ cat > remove_type.mli << EOF
+  > EOF
+
+We generate the .cmi file
+
+  $ ocamlc remove_type.mli
+
+Now we run api-watcher on the two cmi files, there should be a difference:
+
+  $ api-diff ref.cmi remove_type.cmi
+  API changed!
+
+### A file with a modified type:
+
+  $ cat > modify_type.mli << EOF
+  > type t = float
+  > val f : t -> string
+  > EOF
+
+We generate a .cmi file
+
+  $ ocamlc modify_type.mli
+
+Now we run api-watcher on the two cmi files, there should be a difference:
+
+  $ api-diff ref.cmi modify_type.cmi
+  API changed!

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -29,8 +29,6 @@ there should be no diff:
 
 ## Different .cmi files for type tests:
 
-Generate a basic `.mli` files with two types and a function
-
 ### A file with an additional type:
 
   $ cat > add_type.mli <<EOF

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -11,6 +11,8 @@ and simply generate a modified version of it.
 
 ## Identical .cmi files:
 
+Here we generate a basic `.mli` file with two types and a function:
+
   $ cat > ref.mli << EOF
   > type t = int
   > type unused_type = string

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -35,12 +35,12 @@ Here we generate a basic `.mli` files with two types and a function:
 
 ### A file with an additional type:
 
-  $ cat > add_type.mli << EOF
+  $ cat > add_type.mli <<EOF
   > type t = int
   > type added_t = float
   > val f : t -> string
-  > EOF 
-
+  > EOF
+ 
 We generate the .cmi file
 
   $ ocamlc add_type.mli
@@ -48,11 +48,14 @@ We generate the .cmi file
 Now we run api-watcher on the two cmi files, there should be a difference:
 
   $ api-diff ref.cmi add_type.cmi
-  API changed!
+  api-watcher: internal error, uncaught exception:
+               Includemod.Error(_)
+               
+  [125]
 
 ### A file with a removed type:
 
-  $ cat > remove_type.mli << EOF
+  $ cat > remove_type.mli <<EOF
   > EOF
 
 We generate the .cmi file
@@ -66,7 +69,7 @@ Now we run api-watcher on the two cmi files, there should be a difference:
 
 ### A file with a modified type:
 
-  $ cat > modify_type.mli << EOF
+  $ cat > modify_type.mli <<EOF
   > type t = float
   > val f : t -> string
   > EOF
@@ -78,4 +81,7 @@ We generate a .cmi file
 Now we run api-watcher on the two cmi files, there should be a difference:
 
   $ api-diff ref.cmi modify_type.cmi
-  API changed!
+  api-watcher: internal error, uncaught exception:
+               Includemod.Error(_)
+               
+  [125]


### PR DESCRIPTION
This draft pull request is for the issue 8. If merged it Closes #8 .
I am requesting a review on this draft PR because I encounter some errors listed below: @NathanReb @shonfeder @dinakajoy 

```
File "tests/api-diff/run.t", line 1, characters 0-0:
diff --git a/_build/.sandbox/721d8d27ea32e21877549a55015d08cf/default/tests/api-diff/run.t b/_build/.sandbox/721d8d27ea32e21877549a55015d08cf/default/tests/api-diff/run.t.corrected
index c2ff27f..a4a1199 100644
--- a/_build/.sandbox/721d8d27ea32e21877549a55015d08cf/default/tests/api-diff/run.t
+++ b/_build/.sandbox/721d8d27ea32e21877549a55015d08cf/default/tests/api-diff/run.t.corrected
@@ -44,11 +44,17 @@ Here we generate a basic `.mli` files with two types and a function:
 We generate the .cmi file

   $ ocamlc add_type.mli
+  File "add_type.mli", line 5, characters 0-0:
+  Error: Syntax error
+  [2]

Now we run api-watcher on the two cmi files, there should be a difference:

   $ api-diff ref.cmi add_type.cmi
-  API changed!
+  api-watcher: CMI argument: no 'add_type.cmi' file or directory
+  Usage: api-watcher [OPTION]… CMI CMI
+  Try 'api-watcher --help' for more information.
+  [124]
```

```
### A file with a removed type:

@@ -78,4 +84,7 @@ We generate a .cmi file
 Now we run api-watcher on the two cmi files, there should be a difference:

   $ api-diff ref.cmi modify_type.cmi
-  API changed!
+  api-watcher: internal error, uncaught exception:
+               Includemod.Error(_)
+
+  [125]
```
Also the file with a removed type doesn't display anything.