### PR TITLE
Fix Includemod.error

### DIFF
--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -2,15 +2,22 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
   let current = Cmi_format.read_cmi current in
   let reference = Cmi_format.read_cmi reference in
   let typing_env = Env.empty in
-  let coercion =
+  let coercion1 =
     try
       Includemod.signatures typing_env ~mark:Mark_both reference.cmi_sign
         current.cmi_sign
     with
     | Includemod.Error _ -> Tcoerce_none
   in
-  match coercion with
-  | Tcoerce_none -> Printf.printf "API unchanged!\n"
+  let coercion2 =
+    try
+      Includemod.signatures typing_env ~mark:Mark_both current.cmi_sign
+        reference.cmi_sign
+    with
+    | Includemod.Error _ -> Tcoerce_none
+  in
+  match (coercion1, coercion2) with
+  | (Tcoerce_none, Tcoerce_none) -> Printf.printf "API unchanged!\n"
   | _ -> Printf.printf "API changed!\n"
 
 let named f = Cmdliner.Term.(app (const f))

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -2,7 +2,10 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
   let current = Cmi_format.read_cmi current in
   let reference = Cmi_format.read_cmi reference in
   let typing_env = Env.empty in
-  let coercion = fun () -> Includemod.signatures typing_env ~mark:Mark_both reference.cmi_sign current.cmi_sign in
+  let coercion () =
+    Includemod.signatures typing_env ~mark:Mark_both reference.cmi_sign
+      current.cmi_sign
+  in
   match coercion () with
   | Tcoerce_none -> Printf.printf "API unchanged!\n"
   | _ -> Printf.printf "API changed!\n"

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -2,23 +2,15 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
   let current = Cmi_format.read_cmi current in
   let reference = Cmi_format.read_cmi reference in
   let typing_env = Env.empty in
-  let coercion1 =
-    try
+  try
+    let coercion =
       Includemod.signatures typing_env ~mark:Mark_both reference.cmi_sign
         current.cmi_sign
-    with
-    | Includemod.Error _ -> Tcoerce_none
-  in
-  let coercion2 =
-    try
-      Includemod.signatures typing_env ~mark:Mark_both current.cmi_sign
-        reference.cmi_sign
-    with
-    | Includemod.Error _ -> Tcoerce_none
-  in
-  match (coercion1, coercion2) with
-  | (Tcoerce_none, Tcoerce_none) -> Printf.printf "API unchanged!\n"
-  | _ -> Printf.printf "API changed!\n"
+    in
+    match coercion with
+    | Tcoerce_none -> Printf.printf "API unchanged!\n"
+    | _ -> Printf.printf "API changed!\n"
+  with Includemod.Error _ -> Printf.printf "API changed!\n"
 
 let named f = Cmdliner.Term.(app (const f))
 

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -3,8 +3,11 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
   let reference = Cmi_format.read_cmi reference in
   let typing_env = Env.empty in
   let coercion =
-    Includemod.signatures typing_env ~mark:Mark_both reference.cmi_sign
-      current.cmi_sign
+    try
+      Includemod.signatures typing_env ~mark:Mark_both reference.cmi_sign
+        current.cmi_sign
+    with
+    | Includemod.Error _ -> Tcoerce_none
   in
   match coercion with
   | Tcoerce_none -> Printf.printf "API unchanged!\n"

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -2,15 +2,11 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
   let current = Cmi_format.read_cmi current in
   let reference = Cmi_format.read_cmi reference in
   let typing_env = Env.empty in
-  try
-    let coercion =
-      Includemod.signatures typing_env ~mark:Mark_both reference.cmi_sign
-        current.cmi_sign
-    in
-    match coercion with
-    | Tcoerce_none -> Printf.printf "API unchanged!\n"
-    | _ -> Printf.printf "API changed!\n"
-  with Includemod.Error _ -> Printf.printf "API changed!\n"
+  let coercion = fun () -> Includemod.signatures typing_env ~mark:Mark_both reference.cmi_sign current.cmi_sign in
+  match coercion () with
+  | Tcoerce_none -> Printf.printf "API unchanged!\n"
+  | _ -> Printf.printf "API changed!\n"
+  | exception Includemod.Error _ -> Printf.printf "API changed!\n"
 
 let named f = Cmdliner.Term.(app (const f))
 

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -44,10 +44,7 @@ Compile the new .mli file to a .cmi file
 
 Run api-diff and check the output
   $ api-diff ref.cmi add_value.cmi
-  api-watcher: internal error, uncaught exception:
-               Includemod.Error(_)
-               
-  [125]
+  API changed!
 
 Removing a value:
 
@@ -77,7 +74,4 @@ Compile the new .mli file to a .cmi file
 
 Run api-diff and check the output
   $ api-diff ref.cmi modify_value.cmi
-  api-watcher: internal error, uncaught exception:
-               Includemod.Error(_)
-               
-  [125]
+  API changed!


### PR DESCRIPTION
Added try catch which outputs API changed when there is Inlcudemod.error.
Closes https://github.com/NathanReb/ocaml-api-watch/issues/18