### PR TITLE
Add 2-way check in run function

### DIFF
--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -12,11 +12,10 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
     Includemod.signatures typing_env ~mark:Mark_both current.cmi_sign
       reference.cmi_sign
   in
-  try
-    match (coercion1 (), coercion2 ()) with
-    | Tcoerce_none, Tcoerce_none -> Printf.printf "API unchanged!\n"
-    | _, _ -> Printf.printf "API changed!\n"
-  with Includemod.Error _ -> Printf.printf "API changed!\n"
+  match (coercion1 (), coercion2 ()) with
+  | Tcoerce_none, Tcoerce_none -> Printf.printf "API unchanged!\n"
+  | _, _ -> Printf.printf "API changed!\n"
+  | exception Includemod.Error _ -> Printf.printf "API changed!\n"
 
 let named f = Cmdliner.Term.(app (const f))
 

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -4,14 +4,19 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
   let current = Cmi_format.read_cmi current in
   let reference = Cmi_format.read_cmi reference in
   let typing_env = Env.empty in
-  let coercion () =
+  let coercion1 () =
     Includemod.signatures typing_env ~mark:Mark_both reference.cmi_sign
       current.cmi_sign
   in
-  match coercion () with
-  | Tcoerce_none -> Printf.printf "API unchanged!\n"
-  | _ -> Printf.printf "API changed!\n"
-  | exception Includemod.Error _ -> Printf.printf "API changed!\n"
+  let coercion2 () =
+    Includemod.signatures typing_env ~mark:Mark_both current.cmi_sign
+      reference.cmi_sign
+  in
+  try
+    match (coercion1 (), coercion2 ()) with
+    | Tcoerce_none, Tcoerce_none -> Printf.printf "API unchanged!\n"
+    | _, _ -> Printf.printf "API changed!\n"
+  with Includemod.Error _ -> Printf.printf "API changed!\n"
 
 let named f = Cmdliner.Term.(app (const f))
 


### PR DESCRIPTION
The run function now verifies coercion both of reference to current and of current to reference.
I have locally tested it for adding, removing, and modifying types and it works fine. Hopefully, there won't be any problem in #8.
Closes #23 