### PR TITLE
Port tests for changes to modules to expect tests

### DIFF
--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -3,11 +3,56 @@ let%expect_test "test_diff_interface" =
   Format.printf "%b" result;
   [%expect {|false|}]
 
-(* Test Api_watch_diff.diff_interface with the initial mod_ref_signature *)
 open Types
 
+(* The reference mod_ref_signature *)
+let mod_ref_signature : signature =
+  [
+    Sig_module
+      ( Ident.create_persistent "M",
+        Mp_present,
+        {
+          md_type =
+            Mty_signature
+              [
+                Sig_value
+                  ( Ident.create_persistent "x",
+                    {
+                      val_type =
+                        Transient_expr.type_expr
+                          (Transient_expr.create
+                             (Tconstr
+                                ( Path.Pident (Ident.create_persistent "int"),
+                                  [],
+                                  ref Mnil ))
+                             ~level:0 ~scope:0 ~id:0);
+                      val_kind = Val_reg;
+                      val_attributes = [];
+                      val_loc = Location.none;
+                      val_uid = Uid.internal_not_actually_unique;
+                    },
+                    Exported );
+              ];
+          md_attributes = [];
+          md_loc = Location.none;
+          md_uid = Uid.internal_not_actually_unique;
+        },
+        Trec_not,
+        Exported );
+  ]
+
+(* Test Api_watch_diff.diff_interface with the reference mod_ref_signature *)
 let%expect_test "Initial module signature test" =
-  let mod_ref_signature : signature =
+  let result =
+    Api_watch_diff.diff_interface ~reference:mod_ref_signature
+      ~current:mod_ref_signature
+  in
+  Format.printf "%b" result;
+  [%expect {|false|}]
+
+(* Test Api_watch_diff.diff_interface with the interface mod_add_signature *)
+let%expect_test "Generate a new .mli file with an additional module" =
+  let mod_add_signature : signature =
     [
       Sig_module
         ( Ident.create_persistent "M",
@@ -40,11 +85,122 @@ let%expect_test "Initial module signature test" =
           },
           Trec_not,
           Exported );
+      Sig_module
+        ( Ident.create_persistent "N",
+          Mp_present,
+          {
+            md_type =
+              Mty_signature
+                [
+                  Sig_value
+                    ( Ident.create_persistent "y",
+                      {
+                        val_type =
+                          Transient_expr.type_expr
+                            (Transient_expr.create
+                               (Tconstr
+                                  ( Path.Pident (Ident.create_persistent "float"),
+                                    [],
+                                    ref Mnil ))
+                               ~level:0 ~scope:0 ~id:0);
+                        val_kind = Val_reg;
+                        val_attributes = [];
+                        val_loc = Location.none;
+                        val_uid = Uid.internal_not_actually_unique;
+                      },
+                      Exported );
+                ];
+            md_attributes = [];
+            md_loc = Location.none;
+            md_uid = Uid.internal_not_actually_unique;
+          },
+          Trec_not,
+          Exported );
     ]
   in
   let result =
     Api_watch_diff.diff_interface ~reference:mod_ref_signature
-      ~current:mod_ref_signature
+      ~current:mod_add_signature
   in
   Format.printf "%b" result;
-  [%expect {|false|}]
+  [%expect {|true|}]
+
+(* Test Api_watch_diff.diff_interface with the interface mod_remove_signature *)
+let%expect_test "Remove a module from the interface" =
+  let mod_remove_signature : signature = [] in
+  let result =
+    Api_watch_diff.diff_interface ~reference:mod_ref_signature
+      ~current:mod_remove_signature
+  in
+  Format.printf "%b" result;
+  [%expect {|true|}]
+
+(* Test Api_watch_diff.diff_interface with the interface mod_modify_signature *)
+let%expect_test "Modify a module in the interface" =
+  let mod_modify_signature : signature =
+    [
+      Sig_module
+        ( Ident.create_persistent "M",
+          Mp_present,
+          {
+            md_type =
+              Mty_signature
+                [
+                  Sig_value
+                    ( Ident.create_persistent "x",
+                      {
+                        val_type =
+                          Transient_expr.type_expr
+                            (Transient_expr.create
+                               (Tconstr
+                                  ( Path.Pident (Ident.create_persistent "float"),
+                                    [],
+                                    ref Mnil ))
+                               ~level:0 ~scope:0 ~id:0);
+                        val_kind = Val_reg;
+                        val_attributes = [];
+                        val_loc = Location.none;
+                        val_uid = Uid.internal_not_actually_unique;
+                      },
+                      Exported );
+                ];
+            md_attributes = [];
+            md_loc = Location.none;
+            md_uid = Uid.internal_not_actually_unique;
+          },
+          Trec_not,
+          Exported );
+    ]
+  in
+  let result =
+    Api_watch_diff.diff_interface ~reference:mod_ref_signature
+      ~current:mod_modify_signature
+  in
+  Format.printf "%b" result;
+  [%expect.unreachable]
+[@@expect.uncaught_exn
+  {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+
+  (Misc.Fatal_error)
+  Raised at Misc.fatal_errorf.(fun) in file "utils/misc.ml", line 22, characters 14-31
+  Called from Subst.rename_bound_idents.rename_bound_idents in file "typing/subst.ml", line 538, characters 18-33
+  Called from Subst.force_signature_once' in file "typing/subst.ml", line 661, characters 18-50
+  Called from Lazy_backtrack.force in file "utils/lazy_backtrack.ml", line 34, characters 12-15
+  Re-raised at Lazy_backtrack.force in file "utils/lazy_backtrack.ml", line 40, characters 8-15
+  Called from Subst.force_signature_once in file "typing/subst.ml", line 650, characters 18-65
+  Called from Subst.force_signature in file "typing/subst.ml", line 647, characters 32-57
+  Called from Subst.force_modtype in file "typing/subst.ml", line 604, characters 39-59
+  Called from Includemod.modtypes in file "typing/includemod.ml", line 426, characters 15-50
+  Called from Includemod.signature_components in file "typing/includemod.ml", line 758, characters 16-106
+  Called from Includemod.signatures.pair_components in file "typing/includemod.ml", line 653, characters 10-134
+  Called from Includemod.signatures in file "typing/includemod.ml", line 1206, characters 8-111
+  Called from Api_watch_diff.diff_interface.coercion2 in file "lib/api_watch_diff.ml", line 7, characters 4-70
+  Called from Test__Testt.(fun) in file "tests/api-watch-diff/testt.ml", line 176, characters 4-98
+  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19
+
+  Trailing output
+  ---------------
+  >> Fatal error: Ident.rename x |}]

--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -197,3 +197,139 @@ let%expect_test "modifying_a_value_test" =
   in
   Format.printf "%b" result;
   [%expect {|true|}]
+
+(* Signature for mod_ref.mli:
+     > module M : sig val x : int end *)
+let ref_module_signature : signature =
+  [
+    Sig_module
+      ( Ident.create_persistent "M",
+        Mp_present,
+        {
+          md_type =
+            Mty_signature
+              [
+                Sig_value
+                  ( Ident.create_local "x",
+                    {
+                      val_type =
+                        create_expr
+                          (Tconstr (Predef.path_int, [], ref Mnil))
+                          ~level:0 ~scope:0 ~id:0;
+                      val_kind = Val_reg;
+                      val_attributes = [];
+                      val_loc = Location.none;
+                      val_uid = Uid.internal_not_actually_unique;
+                    },
+                    Exported );
+              ];
+          md_attributes = [];
+          md_loc = Location.none;
+          md_uid = Uid.internal_not_actually_unique;
+        },
+        Trec_not,
+        Exported );
+  ]
+
+(* Signature for new module prepended to mod_ref.mli:
+     > module N : sig val y : float end *)
+
+let new_module : signature =
+  [
+    Sig_module
+      ( Ident.create_persistent "N",
+        Mp_present,
+        {
+          md_type =
+            Mty_signature
+              [
+                Sig_value
+                  ( Ident.create_local "y",
+                    {
+                      val_type =
+                        create_expr
+                          (Tconstr (Predef.path_float, [], ref Mnil))
+                          ~level:0 ~scope:0 ~id:0;
+                      val_kind = Val_reg;
+                      val_attributes = [];
+                      val_loc = Location.none;
+                      val_uid = Uid.internal_not_actually_unique;
+                    },
+                    Exported );
+              ];
+          md_attributes = [];
+          md_loc = Location.none;
+          md_uid = Uid.internal_not_actually_unique;
+        },
+        Trec_not,
+        Exported );
+  ]
+
+(* Signature for add_module.mli:
+     > module M : sig val x : int end
+     > module N : sig val y : float end *)
+
+let add_module_signature = new_module @ ref_module_signature
+
+let%expect_test "adding_a_module_test" =
+  let result =
+    Api_watch_diff.diff_interface ~reference:ref_module_signature
+      ~current:add_module_signature
+  in
+  Format.printf "%b" result;
+  [%expect {|true|}]
+
+(* Signature for remove_module.mli:
+     > *)
+
+let remove_module_signature : signature = []
+
+let%expect_test "removing_a_module_test" =
+  let result =
+    Api_watch_diff.diff_interface ~reference:ref_module_signature
+      ~current:remove_module_signature
+  in
+  Format.printf "%b" result;
+  [%expect {|true|}]
+
+(* Signature for modify_module.mli:
+    > module M : sig val x : float end *)
+
+let modify_ref_module_signature : signature =
+  [
+    Sig_module
+      ( Ident.create_persistent "M",
+        Mp_present,
+        {
+          md_type =
+            Mty_signature
+              [
+                Sig_value
+                  ( Ident.create_local "x",
+                    {
+                      val_type =
+                        create_expr
+                          (Tconstr (Predef.path_float, [], ref Mnil))
+                          ~level:0 ~scope:0 ~id:0;
+                      val_kind = Val_reg;
+                      val_attributes = [];
+                      val_loc = Location.none;
+                      val_uid = Uid.internal_not_actually_unique;
+                    },
+                    Exported );
+              ];
+          md_attributes = [];
+          md_loc = Location.none;
+          md_uid = Uid.internal_not_actually_unique;
+        },
+        Trec_not,
+        Exported );
+  ]
+
+let%expect_test "modifying_a_module_test" =
+  let result =
+    Api_watch_diff.diff_interface ~reference:ref_module_signature
+      ~current:modify_ref_module_signature
+  in
+  Format.printf "%b" result;
+  [%expect {|true|}]

--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -16,7 +16,7 @@ let mod_ref_signature : signature =
             Mty_signature
               [
                 Sig_value
-                  ( Ident.create_persistent "x",
+                  ( Ident.create_local "x",
                     {
                       val_type =
                         Transient_expr.type_expr
@@ -62,7 +62,7 @@ let%expect_test "Generate a new .mli file with an additional module" =
               Mty_signature
                 [
                   Sig_value
-                    ( Ident.create_persistent "x",
+                    ( Ident.create_local "x",
                       {
                         val_type =
                           Transient_expr.type_expr
@@ -93,7 +93,7 @@ let%expect_test "Generate a new .mli file with an additional module" =
               Mty_signature
                 [
                   Sig_value
-                    ( Ident.create_persistent "y",
+                    ( Ident.create_local "y",
                       {
                         val_type =
                           Transient_expr.type_expr
@@ -147,7 +147,7 @@ let%expect_test "Modify a module in the interface" =
               Mty_signature
                 [
                   Sig_value
-                    ( Ident.create_persistent "x",
+                    ( Ident.create_local "x",
                       {
                         val_type =
                           Transient_expr.type_expr
@@ -177,30 +177,4 @@ let%expect_test "Modify a module in the interface" =
       ~current:mod_modify_signature
   in
   Format.printf "%b" result;
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-
-  (Misc.Fatal_error)
-  Raised at Misc.fatal_errorf.(fun) in file "utils/misc.ml", line 22, characters 14-31
-  Called from Subst.rename_bound_idents.rename_bound_idents in file "typing/subst.ml", line 538, characters 18-33
-  Called from Subst.force_signature_once' in file "typing/subst.ml", line 661, characters 18-50
-  Called from Lazy_backtrack.force in file "utils/lazy_backtrack.ml", line 34, characters 12-15
-  Re-raised at Lazy_backtrack.force in file "utils/lazy_backtrack.ml", line 40, characters 8-15
-  Called from Subst.force_signature_once in file "typing/subst.ml", line 650, characters 18-65
-  Called from Subst.force_signature in file "typing/subst.ml", line 647, characters 32-57
-  Called from Subst.force_modtype in file "typing/subst.ml", line 604, characters 39-59
-  Called from Includemod.modtypes in file "typing/includemod.ml", line 426, characters 15-50
-  Called from Includemod.signature_components in file "typing/includemod.ml", line 758, characters 16-106
-  Called from Includemod.signatures.pair_components in file "typing/includemod.ml", line 653, characters 10-134
-  Called from Includemod.signatures in file "typing/includemod.ml", line 1206, characters 8-111
-  Called from Api_watch_diff.diff_interface.coercion2 in file "lib/api_watch_diff.ml", line 7, characters 4-70
-  Called from Test.(fun) in file "tests/api-watch-diff/test.ml", line 176, characters 4-98
-  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19
-
-  Trailing output
-  ---------------
-  >> Fatal error: Ident.rename x |}]
+  [%expect {|true|}]

--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -198,7 +198,7 @@ let%expect_test "Modify a module in the interface" =
   Called from Includemod.signatures.pair_components in file "typing/includemod.ml", line 653, characters 10-134
   Called from Includemod.signatures in file "typing/includemod.ml", line 1206, characters 8-111
   Called from Api_watch_diff.diff_interface.coercion2 in file "lib/api_watch_diff.ml", line 7, characters 4-70
-  Called from Test__Testt.(fun) in file "tests/api-watch-diff/testt.ml", line 176, characters 4-98
+  Called from Test.(fun) in file "tests/api-watch-diff/test.ml", line 176, characters 4-98
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19
 
   Trailing output

--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -200,6 +200,7 @@ let%expect_test "modifying_a_value_test" =
 
 (* Signature for mod_ref.mli:
      > module M : sig val x : int end *)
+
 let ref_module_signature : signature =
   [
     Sig_module
@@ -212,10 +213,7 @@ let ref_module_signature : signature =
                 Sig_value
                   ( Ident.create_local "x",
                     {
-                      val_type =
-                        create_expr
-                          (Tconstr (Predef.path_int, [], ref Mnil))
-                          ~level:0 ~scope:0 ~id:0;
+                      val_type = Predef.type_int;
                       val_kind = Val_reg;
                       val_attributes = [];
                       val_loc = Location.none;
@@ -246,10 +244,7 @@ let new_module : signature =
                 Sig_value
                   ( Ident.create_local "y",
                     {
-                      val_type =
-                        create_expr
-                          (Tconstr (Predef.path_float, [], ref Mnil))
-                          ~level:0 ~scope:0 ~id:0;
+                      val_type = Predef.type_float;
                       val_kind = Val_reg;
                       val_attributes = [];
                       val_loc = Location.none;
@@ -307,10 +302,7 @@ let modify_ref_module_signature : signature =
                 Sig_value
                   ( Ident.create_local "x",
                     {
-                      val_type =
-                        create_expr
-                          (Tconstr (Predef.path_float, [], ref Mnil))
-                          ~level:0 ~scope:0 ~id:0;
+                      val_type = Predef.type_float;
                       val_kind = Val_reg;
                       val_attributes = [];
                       val_loc = Location.none;

--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -8,40 +8,43 @@ open Types
 
 let%expect_test "Initial module signature test" =
   let mod_ref_signature : signature =
-    [ Sig_module (
-        Ident.create_persistent "M",
-        Mp_present,
-        {
-          md_type = Mty_signature [
-            Sig_value (
-              Ident.create_persistent "x",
-              {
-                val_type =
-                  Transient_expr.type_expr
-                    (Transient_expr.create (
-                      Tconstr (Path.Pident (Ident.create_persistent "int"), [], ref Mnil))
-                        ~level:0 ~scope:0 ~id:0
-                    );
-                val_kind = Val_reg;
-                val_attributes = [];
-                val_loc = Location.none;
-                val_uid = Uid.internal_not_actually_unique;
-              },
-              Exported
-            )
-          ];
-          md_attributes = [];
-          md_loc = Location.none;
-          md_uid = Uid.internal_not_actually_unique;
-        },
-        Trec_not,
-        Exported
-      )
+    [
+      Sig_module
+        ( Ident.create_persistent "M",
+          Mp_present,
+          {
+            md_type =
+              Mty_signature
+                [
+                  Sig_value
+                    ( Ident.create_persistent "x",
+                      {
+                        val_type =
+                          Transient_expr.type_expr
+                            (Transient_expr.create
+                               (Tconstr
+                                  ( Path.Pident (Ident.create_persistent "int"),
+                                    [],
+                                    ref Mnil ))
+                               ~level:0 ~scope:0 ~id:0);
+                        val_kind = Val_reg;
+                        val_attributes = [];
+                        val_loc = Location.none;
+                        val_uid = Uid.internal_not_actually_unique;
+                      },
+                      Exported );
+                ];
+            md_attributes = [];
+            md_loc = Location.none;
+            md_uid = Uid.internal_not_actually_unique;
+          },
+          Trec_not,
+          Exported );
     ]
   in
   let result =
-    Api_watch_diff.diff_interface ~reference:mod_ref_signature ~current:mod_ref_signature
+    Api_watch_diff.diff_interface ~reference:mod_ref_signature
+      ~current:mod_ref_signature
   in
   Format.printf "%b" result;
   [%expect {|false|}]
-

--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -2,3 +2,35 @@ let%expect_test "test_diff_interface" =
   let result = Api_watch_diff.diff_interface ~reference:[] ~current:[] in
   Format.printf "%b" result;
   [%expect {|false|}]
+
+(* Test Api_watch_diff.diff_interface with the initial mod_ref_signature *)
+open Types
+
+let%expect_test "Initial module signature test" =
+  let module_identifier = Ident.create_persistent "M" in
+  let value_identifier = Ident.create_persistent "int" in
+  let int_type_expr =
+    Tconstr (Path.Pident (value_identifier), [], ref Mnil)
+  in
+  let value_description :value_description =
+    { val_type = int_type_expr;
+      val_kind = Val_reg
+      val_attributes = [];
+      val_loc = Location.none;
+      val_uid = Uid.create ()
+    }
+  in
+  let module_type =
+    Mty_signature [Sig_value (value_identifier, value_description, Public)]
+  in
+  let mod_ref_signature : signature =
+    [Sig_module (module_identifier,
+                       Mp_present,
+                       module_type,
+                       Nonrecursive,
+                       Public)]
+  in
+  let diff_result = Api_watch_diff.diff_interface [mod_ref_signature] in
+
+  Format.printf "%b" diff_result;
+  [%expect {| API unchanged! |}]

--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -292,46 +292,46 @@ let%expect_test "Modifying a type" =
 (* Signature for mod_ref.mli:
      > module M : sig val x : int end *)
 
-let ref_module_m_signature =
-  [
-    Sig_module
-      ( Ident.create_persistent "M",
-        Mp_present,
-        {
-          md_type =
-            Mty_signature
-              [
-                Sig_value
-                  ( Ident.create_local "x",
-                    {
-                      val_type = Predef.type_int;
-                      val_kind = Val_reg;
-                      val_attributes = [];
-                      val_loc = Location.none;
-                      val_uid = Uid.internal_not_actually_unique;
-                    },
-                    Exported );
-              ];
-          md_attributes = [];
-          md_loc = Location.none;
-          md_uid = Uid.internal_not_actually_unique;
-        },
-        Trec_not,
-        Exported );
-  ]
+let module_m =
+  Sig_module
+    ( Ident.create_persistent "M",
+      Mp_present,
+      {
+        md_type =
+          Mty_signature
+            [
+              Sig_value
+                ( Ident.create_local "x",
+                  {
+                    val_type = Predef.type_int;
+                    val_kind = Val_reg;
+                    val_attributes = [];
+                    val_loc = Location.none;
+                    val_uid = Uid.internal_not_actually_unique;
+                  },
+                  Exported );
+            ];
+        md_attributes = [];
+        md_loc = Location.none;
+        md_uid = Uid.internal_not_actually_unique;
+      },
+      Trec_not,
+      Exported )
+
+let ref_module_signature = [ module_m ]
 
 let%expect_test "unchanged_module" =
   let result =
-    Api_watch_diff.diff_interface ~reference:ref_module_m_signature
-      ~current:ref_module_m_signature
+    Api_watch_diff.diff_interface ~reference:ref_module_signature
+      ~current:ref_module_signature
   in
   Format.printf "%b" result;
   [%expect {|false|}]
 
-(* Signature for new module prepended to mod_ref.mli:
+(* Signature for module n in mod_ref.mli:
      > module N : sig val y : float end *)
 
-let module_n_signature =
+let module_n =
   Sig_module
     ( Ident.create_persistent "N",
       Mp_present,
@@ -361,11 +361,11 @@ let module_n_signature =
      > module M : sig val x : int end
      > module N : sig val y : float end *)
 
-let add_module_signature = module_n_signature :: ref_module_m_signature
+let add_module_signature = [ module_m; module_n ]
 
 let%expect_test "adding_a_module_test" =
   let result =
-    Api_watch_diff.diff_interface ~reference:ref_module_m_signature
+    Api_watch_diff.diff_interface ~reference:ref_module_signature
       ~current:add_module_signature
   in
   Format.printf "%b" result;
@@ -378,7 +378,7 @@ let remove_module_signature = []
 
 let%expect_test "removing_a_module_test" =
   let result =
-    Api_watch_diff.diff_interface ~reference:ref_module_m_signature
+    Api_watch_diff.diff_interface ~reference:ref_module_signature
       ~current:remove_module_signature
   in
   Format.printf "%b" result;
@@ -387,38 +387,38 @@ let%expect_test "removing_a_module_test" =
 (* Signature for modify_module.mli:
     > module M : sig val x : float end *)
 
-let modify_ref_module_m_signature =
-  [
-    Sig_module
-      ( Ident.create_persistent "M",
-        Mp_present,
-        {
-          md_type =
-            Mty_signature
-              [
-                Sig_value
-                  ( Ident.create_local "x",
-                    {
-                      val_type = Predef.type_float;
-                      val_kind = Val_reg;
-                      val_attributes = [];
-                      val_loc = Location.none;
-                      val_uid = Uid.internal_not_actually_unique;
-                    },
-                    Exported );
-              ];
-          md_attributes = [];
-          md_loc = Location.none;
-          md_uid = Uid.internal_not_actually_unique;
-        },
-        Trec_not,
-        Exported );
-  ]
+let modify_module_m =
+  Sig_module
+    ( Ident.create_persistent "M",
+      Mp_present,
+      {
+        md_type =
+          Mty_signature
+            [
+              Sig_value
+                ( Ident.create_local "x",
+                  {
+                    val_type = Predef.type_float;
+                    val_kind = Val_reg;
+                    val_attributes = [];
+                    val_loc = Location.none;
+                    val_uid = Uid.internal_not_actually_unique;
+                  },
+                  Exported );
+            ];
+        md_attributes = [];
+        md_loc = Location.none;
+        md_uid = Uid.internal_not_actually_unique;
+      },
+      Trec_not,
+      Exported )
+
+let modify_ref_module_signature = [ modify_module_m ]
 
 let%expect_test "modifying_a_module_test" =
   let result =
-    Api_watch_diff.diff_interface ~reference:ref_module_m_signature
-      ~current:modify_ref_module_m_signature
+    Api_watch_diff.diff_interface ~reference:ref_module_signature
+      ~current:modify_ref_module_signature
   in
   Format.printf "%b" result;
   [%expect {|true|}]


### PR DESCRIPTION
The PR is a WIP closes #34 

I have made some progress with the expected tests for modules but I keep encountering the error below. In the val_type a `type_expr` is needed but I can seem to find the signature of `type_expr` in the `ocaml/typing/types.mli`. The one present is a declaration on the line https://github.com/ocaml/ocaml/blob/18c4510e6c8693c1feffb4871f429987a1d714ff/typing/types.mli#L58.  So I had to put a `type_desc` as a placeholder. At the moment I'm trying to locate the usage of `type_expr` in the compiler in order to replicate it.

Error:
```
...:~/ocaml-api-watch-fork/tests/api-watch-diff$ dune runtest
Entering directory '/home/munga/ocaml-api-watch-fork'
File "tests/api-watch-diff/test.ml", line 16, characters 17-30:
16 |     { val_type = int_type_expr;
                      ^^^^^^^^^^^^^
Error: This expression has type type_desc
       but an expression was expected of type type_expr
```