### PR TITLE
Fixed implementation for diffing values more general than one another

### DIFF
--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -213,3 +213,17 @@ let%expect_test "Modifying a module" =
   in
   Format.printf "%a" pp_diff_list result;
   [%expect {|[Any]|}]
+
+let%expect_test "Reference more general than Current interface" =
+  let reference = Test_helpers.compile_interface {|val x : 'a list|} in
+  let current = Test_helpers.compile_interface {|val x : float list|} in
+  let result = Api_watch_diff.diff_interface ~reference ~current in
+  Format.printf "%a" pp_diff_list result;
+  [%expect {|[Value (x, Modified)]|}]
+
+let%expect_test "Current more general than Reference interface" =
+  let reference = Test_helpers.compile_interface {|val x : int list|} in
+  let current = Test_helpers.compile_interface {|val x : 'a list|} in
+  let result = Api_watch_diff.diff_interface ~reference ~current in
+  Format.printf "%a" pp_diff_list result;
+  [%expect {|[Value (x, Modified)]|}]

--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -214,16 +214,16 @@ let%expect_test "Modifying a module" =
   Format.printf "%a" pp_diff_list result;
   [%expect {|[Any]|}]
 
-let%expect_test "Reference more general than Current interface" =
-  let reference = Test_helpers.compile_interface {|val x : 'a list|} in
-  let current = Test_helpers.compile_interface {|val x : float list|} in
-  let result = Api_watch_diff.diff_interface ~reference ~current in
+let%expect_test "One value more general than the other" =
+  let general = Test_helpers.compile_interface {|val x : 'a list|} in
+  let specialized = Test_helpers.compile_interface {|val x : float list|} in
+  let result =
+    Api_watch_diff.diff_interface ~reference:general ~current:specialized
+  in
   Format.printf "%a" pp_diff_list result;
-  [%expect {|[Value (x, Modified)]|}]
-
-let%expect_test "Current more general than Reference interface" =
-  let reference = Test_helpers.compile_interface {|val x : int list|} in
-  let current = Test_helpers.compile_interface {|val x : 'a list|} in
-  let result = Api_watch_diff.diff_interface ~reference ~current in
-  Format.printf "%a" pp_diff_list result;
+  [%expect {|[Value (x, Modified)]|}];
+  let rev_result =
+    Api_watch_diff.diff_interface ~reference:specialized ~current:general
+  in
+  Format.printf "%a" pp_diff_list rev_result;
   [%expect {|[Value (x, Modified)]|}]


### PR DESCRIPTION
The goal of this PR is to enhance our implementation to handle diffing of values with more general types than one another, ensuring accurate detection and reporting of modifications.

I have also added simple expect tests for handling the both the cases : 

- when the reference signature is more general than the current signature
- when the current signature is more general than the reference signature



