### PR TITLE
Fixed implementation for abstract types

### DIFF
--- a/lib/api_watch_diff.ml
+++ b/lib/api_watch_diff.ml
@@ -22,7 +22,7 @@ let add_manifest_to_abstract_types ~ref_sig ~curr_sig =
         match item with
         | Sig_type (id, decl, _, _)
           when decl.type_kind = Type_abstract && decl.type_manifest = None ->
-            (Ident.name id, id, decl) :: acc
+            (Ident.name id, id) :: acc
         | _ -> acc)
       [] ref_sig
   in
@@ -32,8 +32,8 @@ let add_manifest_to_abstract_types ~ref_sig ~curr_sig =
       | Sig_type (id, decl, rec_st, visibility)
         when decl.type_kind = Type_abstract && decl.type_manifest = None -> (
           let name = Ident.name id in
-          match List.find_opt (fun (n, _, _) -> n = name) ref_types with
-          | Some (_, ref_id, _) ->
+          match List.find_opt (fun (n, _) -> n = name) ref_types with
+          | Some (_, ref_id) ->
               let ref_path = Path.Pident ref_id in
               let new_decl =
                 {

--- a/lib/api_watch_diff.ml
+++ b/lib/api_watch_diff.ml
@@ -26,7 +26,7 @@ let set_type_equality ref_id curr_decl =
     type_manifest = Some (Btype.newgenty (Tconstr (ref_path, [], ref Mnil)));
   }
 
-let modify_curr_sig_manifest ~ref_sig ~curr_sig =
+let set_type_equalities ~ref_sig ~curr_sig =
   let ref_abstract_types = extract_abstract_types ref_sig in
   List.map
     (fun item ->
@@ -46,7 +46,7 @@ let modify_curr_sig_manifest ~ref_sig ~curr_sig =
     curr_sig
 
 let env_setup ~ref_sig ~curr_sig =
-  let modified_curr_sig = modify_curr_sig_manifest ~ref_sig ~curr_sig in
+  let modified_curr_sig = set_type_equalities ~ref_sig ~curr_sig in
   let env = Env.empty in
   let env = Env.in_signature true env in
   let env = Env.add_signature ref_sig env in

--- a/lib/api_watch_diff.ml
+++ b/lib/api_watch_diff.ml
@@ -15,6 +15,38 @@ let env_setup ~ref_sig ~curr_sig =
   let env = Env.add_signature ref_sig env in
   Env.add_signature curr_sig env
 
+let add_manifest_to_abstract_types ~ref_sig ~curr_sig =
+  let ref_types =
+    List.fold_left
+      (fun acc item ->
+        match item with
+        | Sig_type (id, decl, _, _)
+          when decl.type_kind = Type_abstract && decl.type_manifest = None ->
+            (Ident.name id, id, decl) :: acc
+        | _ -> acc)
+      [] ref_sig
+  in
+  List.map
+    (fun item ->
+      match item with
+      | Sig_type (id, decl, rec_st, visibility)
+        when decl.type_kind = Type_abstract && decl.type_manifest = None -> (
+          let name = Ident.name id in
+          match List.find_opt (fun (n, _, _) -> n = name) ref_types with
+          | Some (_, ref_id, _) ->
+              let ref_path = Path.Pident ref_id in
+              let new_decl =
+                {
+                  decl with
+                  type_manifest =
+                    Some (Btype.newgenty (Tconstr (ref_path, [], ref Mnil)));
+                }
+              in
+              Sig_type (id, new_decl, rec_st, visibility)
+          | None -> item)
+      | _ -> item)
+    curr_sig
+
 let extract_values tbl items =
   List.fold_left
     (fun tbl item ->
@@ -38,9 +70,12 @@ let diff_value ~typing_env ~val_name ~reference ~current =
   | exception Includecore.Dont_match _ -> Some ()
 
 let compare_values ~reference ~current =
-  let env = env_setup ~ref_sig:reference ~curr_sig:current in
+  let modified_current =
+    add_manifest_to_abstract_types ~ref_sig:reference ~curr_sig:current
+  in
+  let env = env_setup ~ref_sig:reference ~curr_sig:modified_current in
   let ref_values = extract_values FieldMap.empty reference in
-  let curr_values = extract_values FieldMap.empty current in
+  let curr_values = extract_values FieldMap.empty modified_current in
   let diffs =
     FieldMap.fold
       (fun val_name curr_vd acc ->

--- a/lib/api_watch_diff.ml
+++ b/lib/api_watch_diff.ml
@@ -26,7 +26,8 @@ let set_type_equality ref_id curr_decl =
     type_manifest = Some (Btype.newgenty (Tconstr (ref_path, [], ref Mnil)));
   }
 
-let modify_curr_sig_manifest ref_type_map curr_sig =
+let modify_curr_sig_manifest ~ref_sig ~curr_sig =
+  let ref_abstract_types = extract_abstract_types ref_sig in
   List.map
     (fun item ->
       match item with
@@ -36,7 +37,7 @@ let modify_curr_sig_manifest ref_type_map curr_sig =
             rec_st,
             visibility ) -> (
           let name = Ident.name id in
-          match FieldMap.find_opt name ref_type_map with
+          match FieldMap.find_opt name ref_abstract_types with
           | Some ref_id ->
               let new_decl = set_type_equality ref_id decl in
               Sig_type (id, new_decl, rec_st, visibility)
@@ -45,10 +46,7 @@ let modify_curr_sig_manifest ref_type_map curr_sig =
     curr_sig
 
 let env_setup ~ref_sig ~curr_sig =
-  let ref_abstract_types = extract_abstract_types ref_sig in
-  let modified_curr_sig =
-    modify_curr_sig_manifest ref_abstract_types curr_sig
-  in
+  let modified_curr_sig = modify_curr_sig_manifest ~ref_sig ~curr_sig in
   let env = Env.empty in
   let env = Env.in_signature true env in
   let env = Env.add_signature ref_sig env in

--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -134,14 +134,6 @@ let%expect_test "Modifying a simple type" =
   Format.printf "%a" pp_diff_list result;
   [%expect {|[Any]|}]
 
-let modify_type_in_value_signature =
-  Test_helpers.compile_interface
-    {|
-    type t = float
-    type unused_type = string
-    val f : t -> string
-    |}
-
 let%expect_test "Modifying a type used in a value" =
   let reference =
     Test_helpers.compile_interface
@@ -227,3 +219,20 @@ let%expect_test "One value more general than the other" =
   in
   Format.printf "%a" pp_diff_list rev_result;
   [%expect {|[Value (x, Modified)]|}]
+
+let%expect_test "Same abstract type" =
+  let reference =
+    Test_helpers.compile_interface {|
+    type t
+    val x : t
+  |}
+  in
+  let current =
+    Test_helpers.compile_interface {|
+    type t
+    val x : t
+  |}
+  in
+  let result = Api_watch_diff.diff_interface ~reference ~current in
+  Format.printf "%a" pp_diff_list result;
+  [%expect {|[]|}]


### PR DESCRIPTION
Fixes #44. 

I have modified the current signature to reflect the type equality for abstract types with the reference signature. I have also added an equality test case for abstract types and it works as required.