### PR TITLE
Added failing test for identical values 

### DIFF
--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -643,7 +643,7 @@ let%expect_test "Changing from record to variant type" =
   Format.printf "%a" pp_diff_list result;
   [%expect {|[Any]|}]
 
-let%expect_test "New test: Identical values" =
+let%expect_test "Values referencing types with constructors, identical" =
   let reference =
     compile_interface
       {|
@@ -661,3 +661,22 @@ let%expect_test "New test: Identical values" =
   let result = diff_interface ~reference ~current in
   Format.printf "%a" pp_diff_list result;
   [%expect {|[]|}]
+
+let%expect_test " Values referencing types with constructors, modified" =
+  let reference =
+    compile_interface
+      {|
+    type ('a, 'b) result = Ok of 'a | Error of 'b
+    val x : (int ,string) result
+  |}
+  in
+  let current =
+    compile_interface
+      {|
+     type ('a, 'b) result = Ok of 'a | Error of 'b
+    val x : (float ,string) result
+  |}
+  in
+  let result = diff_interface ~reference ~current in
+  Format.printf "%a" pp_diff_list result;
+  [%expect {|[Value (x, Modified)]|}]

--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -643,7 +643,7 @@ let%expect_test "Changing from record to variant type" =
   Format.printf "%a" pp_diff_list result;
   [%expect {|[Any]|}]
 
-let%expect_test "Values referencing types with constructors, identical" =
+let%expect_test "Values referencing types with parameters, identical" =
   let reference =
     compile_interface
       {|
@@ -662,7 +662,7 @@ let%expect_test "Values referencing types with constructors, identical" =
   Format.printf "%a" pp_diff_list result;
   [%expect {|[]|}]
 
-let%expect_test " Values referencing types with constructors, modified" =
+let%expect_test " Values referencing types with parameters, modified" =
   let reference =
     compile_interface
       {|

--- a/tests/api-watch-diff/test.ml
+++ b/tests/api-watch-diff/test.ml
@@ -642,3 +642,22 @@ let%expect_test "Changing from record to variant type" =
   let result = diff_interface ~reference ~current in
   Format.printf "%a" pp_diff_list result;
   [%expect {|[Any]|}]
+
+let%expect_test "New test: Identical values" =
+  let reference =
+    compile_interface
+      {|
+    type ('a, 'b) result = Ok of 'a | Error of 'b
+    val x : (int ,string) result
+  |}
+  in
+  let current =
+    compile_interface
+      {|
+     type ('a, 'b) result = Ok of 'a | Error of 'b
+    val x : (int ,string) result
+  |}
+  in
+  let result = diff_interface ~reference ~current in
+  Format.printf "%a" pp_diff_list result;
+  [%expect {|[]|}]


### PR DESCRIPTION
This is the behaviour I was talking about. For values referencing types with constructors, our implementation isn't working as expected.