### PR TITLE
Upgraded to OCaml 5.2 and OCamlformat 0.26.2

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version=0.26.1
+version=0.26.2

--- a/api-watch.opam
+++ b/api-watch.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/NathanReb/ocaml-api-watch"
 bug-reports: "https://github.com/NathanReb/ocaml-api-watch/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "5.1.0" & < "5.2.0"}
+  "ocaml" {>= "5.2.0" & < "5.3.0"}
   "ppx_expect" {with-test}
   "ppx_deriving"
   "logs"

--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,7 @@
  (name api-watch)
  (synopsis "Libraries and tools to keep watch on your OCaml lib's API changes")
  (depends
-  (ocaml (and (>= 5.1.0) (< 5.2.0)))
+  (ocaml (and (>= 5.2.0) (< 5.3.0)))
   (ppx_expect :with-test)
   ppx_deriving
   logs


### PR DESCRIPTION
This PR upgrades the project to use OCaml version 5.2 instead of 5.1, and also upgrades OCamlformat version from 0.26.1 to 0.26.2 to make it compatible with the upgraded compiler.