### PR TITLE
Added implementation to get a merged signature for an entire dune built library

### DIFF
--- a/api-watch.opam
+++ b/api-watch.opam
@@ -12,6 +12,7 @@ depends: [
   "ppx_expect" {with-test}
   "ppx_deriving"
   "logs"
+  "containers"
   "cmdliner" {>= "1.1.0"}
   "diffutils"
   "odoc" {with-doc}

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -1,13 +1,19 @@
 let run (`Ref_cmi reference) (`Current_cmi current) =
-  let reference_sig, current_sig, module_name =
+  let open CCResult.Infix in
+  let* reference_sig, current_sig, module_name =
     if Sys.is_directory reference && Sys.is_directory current then
-      let reference_sig = Api_watch.Library.load reference in
-      let current_sig = Api_watch.Library.load current in
+      let+ reference_sig = Api_watch.Library.load reference
+      and+ current_sig = Api_watch.Library.load current in
       let module_name = Filename.basename current in
       (reference_sig, current_sig, module_name)
     else
-      let reference_cmi = Cmi_format.read_cmi reference in
-      let current_cmi = Cmi_format.read_cmi current in
+      let+ reference_cmi =
+        try Ok (Cmi_format.read_cmi reference)
+        with e -> Error (Printexc.to_string e)
+      and+ current_cmi =
+        try Ok (Cmi_format.read_cmi current)
+        with e -> Error (Printexc.to_string e)
+      in
       let module_name = current_cmi.cmi_name in
       (reference_cmi.cmi_sign, current_cmi.cmi_sign, module_name)
   in
@@ -16,7 +22,7 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
       ~current:current_sig
   in
   match diff with
-  | None -> 0
+  | None -> Ok 0
   | Some diff ->
       let text_diff = Api_watch.Text_diff.from_diff diff in
       let print_module_diff module_path diff =
@@ -25,7 +31,7 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
         Printf.printf "\n"
       in
       Api_watch.String_map.iter print_module_diff text_diff;
-      1
+      Ok 1
 
 let named f = Cmdliner.Term.(app (const f))
 
@@ -48,6 +54,13 @@ let info =
   Cmd.info "api-watcher" ~version:"%%VERSION%%" ~exits:Cmd.Exit.defaults
     ~doc:"List API changes between two versions of a library"
 
-let term = Cmdliner.Term.(const run $ ref_cmi $ current_cmi)
+let run_with_error_handling ref_cmi current_cmi =
+  match run ref_cmi current_cmi with
+  | Ok code -> code
+  | Error msg ->
+      Printf.eprintf "Error: %s\n" msg;
+      2
+
+let term = Cmdliner.Term.(const run_with_error_handling $ ref_cmi $ current_cmi)
 let main = Cmdliner.Cmd.v info term
 let () = Stdlib.exit @@ Cmdliner.Cmd.eval' main

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -5,15 +5,14 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
       let+ reference_sig = Api_watch.Library.load reference
       and+ current_sig = Api_watch.Library.load current in
       let module_name =
-        let rec find_parent_dir path =
+        let rec find_library_name path =
           let parent = Filename.dirname path in
-          if
-            Filename.basename parent = "_build"
-            || Filename.basename parent = "_opam"
-          then Filename.basename (Filename.dirname parent)
-          else find_parent_dir parent
+          if Filename.basename parent = "_build" then
+            Filename.basename (Filename.dirname parent)
+          else if Filename.basename parent = "_opam" then Filename.basename path
+          else find_library_name parent
         in
-        find_parent_dir current
+        find_library_name current
       in
       (reference_sig, current_sig, module_name)
     else

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -1,9 +1,19 @@
 let run (`Ref_cmi reference) (`Current_cmi current) =
-  let current = Cmi_format.read_cmi current in
-  let reference = Cmi_format.read_cmi reference in
+  let reference_sig, current_sig, module_name =
+    if Sys.is_directory reference && Sys.is_directory current then
+      let reference_sig = Api_watch.Library.load reference in
+      let current_sig = Api_watch.Library.load current in
+      let module_name = Filename.basename current in
+      (reference_sig, current_sig, module_name)
+    else
+      let reference_cmi = Cmi_format.read_cmi reference in
+      let current_cmi = Cmi_format.read_cmi current in
+      let module_name = current_cmi.cmi_name in
+      (reference_cmi.cmi_sign, current_cmi.cmi_sign, module_name)
+  in
   let diff =
-    Api_watch.Diff.interface ~module_name:current.cmi_name
-      ~reference:reference.cmi_sign ~current:current.cmi_sign
+    Api_watch.Diff.interface ~module_name ~reference:reference_sig
+      ~current:current_sig
   in
   match diff with
   | None -> 0

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -25,7 +25,7 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
       ~current:current_sig
   in
   match diff with
-  | None -> Ok ()
+  | None -> Ok 0
   | Some diff ->
       let text_diff = Api_watch.Text_diff.from_diff diff in
       let print_module_diff module_path diff =
@@ -34,7 +34,7 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
         Printf.printf "\n"
       in
       Api_watch.String_map.iter print_module_diff text_diff;
-      Ok ()
+      Ok 1
 
 let named f = Cmdliner.Term.(app (const f))
 
@@ -60,5 +60,5 @@ let info =
 let term = Cmdliner.Term.(const run $ ref_cmi $ current_cmi)
 
 let () =
-  let exit_code = Cmdliner.Cmd.eval_result (Cmdliner.Cmd.v info term) in
+  let exit_code = Cmdliner.Cmd.eval_result' (Cmdliner.Cmd.v info term) in
   exit exit_code

--- a/bin/api_diff.ml
+++ b/bin/api_diff.ml
@@ -4,7 +4,17 @@ let run (`Ref_cmi reference) (`Current_cmi current) =
     if Sys.is_directory reference && Sys.is_directory current then
       let+ reference_sig = Api_watch.Library.load reference
       and+ current_sig = Api_watch.Library.load current in
-      let module_name = Filename.basename current in
+      let module_name =
+        let rec find_parent_dir path =
+          let parent = Filename.dirname path in
+          if
+            Filename.basename parent = "_build"
+            || Filename.basename parent = "_opam"
+          then Filename.basename (Filename.dirname parent)
+          else find_parent_dir parent
+        in
+        find_parent_dir current
+      in
       (reference_sig, current_sig, module_name)
     else
       let+ reference_cmi, _ = Api_watch.Library.load_cmi reference

--- a/dune-project
+++ b/dune-project
@@ -19,5 +19,6 @@
   (ppx_expect :with-test)
   ppx_deriving
   logs
+  containers
   (cmdliner (>= 1.1.0))
   diffutils))

--- a/lib/api_watch.ml
+++ b/lib/api_watch.ml
@@ -1,3 +1,4 @@
 module String_map = String_map
 module Diff = Diff
 module Text_diff = Text_diff
+module Library = Library

--- a/lib/dune
+++ b/lib/dune
@@ -3,4 +3,4 @@
  (public_name api-watch)
  (preprocess
   (pps ppx_deriving.std))
- (libraries compiler-libs.common diffutils unix))
+ (libraries compiler-libs.common diffutils unix containers))

--- a/lib/dune
+++ b/lib/dune
@@ -3,4 +3,4 @@
  (public_name api-watch)
  (preprocess
   (pps ppx_deriving.std))
- (libraries compiler-libs.common diffutils))
+ (libraries compiler-libs.common diffutils unix))

--- a/lib/library.ml
+++ b/lib/library.ml
@@ -1,21 +1,16 @@
 let collect_cmi_files dir =
-  let open CCResult.Infix in
-  let* files =
-    try Ok (Sys.readdir dir)
-    with Sys_error e ->
-      Error (Printf.sprintf "Error reading directory %s: %s" dir e)
-  in
-  Array.fold_left
-    (fun acc_res file ->
-      let* acc = acc_res in
-      let path = Filename.concat dir file in
-      if
-        Sys.file_exists path
-        && (not (Sys.is_directory path))
-        && Filename.check_suffix file ".cmi"
-      then Ok (path :: acc)
-      else Ok acc)
-    (Ok []) files
+  try
+    let files = Sys.readdir dir in
+    Ok
+      (Array.fold_left
+         (fun acc file ->
+           let path = Filename.concat dir file in
+           if (not (Sys.is_directory path)) && Filename.check_suffix file ".cmi"
+           then path :: acc
+           else acc)
+         [] files)
+  with Sys_error e ->
+    Error (Printf.sprintf "Error reading directory %s: %s" dir e)
 
 let load_cmi file_path =
   try
@@ -23,49 +18,35 @@ let load_cmi file_path =
     Ok (cmi_infos.cmi_sign, cmi_infos.cmi_name)
   with e -> Error (Printexc.to_string e)
 
-let find_build_artifacts_dir project_path =
-  let build_dir = Filename.concat project_path "_build/default/lib" in
-  try
-    let dirs = Sys.readdir build_dir |> Array.to_list in
-    match List.find_opt (fun dir -> Filename.check_suffix dir ".objs") dirs with
-    | Some objs_dir ->
-        let full_objs_path = Filename.concat build_dir objs_dir in
-        Some (Filename.concat full_objs_path "byte")
-    | None -> None
-  with Sys_error _ -> None
-
 let load project_path =
   let open CCResult.Infix in
-  match find_build_artifacts_dir project_path with
-  | Some artifacts_dir ->
-      let* cmi_files = collect_cmi_files artifacts_dir in
-      let* signatures =
-        CCResult.map_l
-          (fun cmi_file ->
-            let+ signature, module_name = load_cmi cmi_file in
-            (module_name, signature))
-          cmi_files
-      in
-      let merged_signature =
-        List.fold_left
-          (fun acc (module_name, signature) ->
-            String_map.add module_name signature acc)
-          String_map.empty signatures
-      in
-      Ok
-        (String_map.fold
-           (fun module_name module_sig acc ->
-             Types.Sig_module
-               ( Ident.create_local module_name,
-                 Mp_present,
-                 {
-                   md_type = Mty_signature module_sig;
-                   md_attributes = [];
-                   md_loc = Location.none;
-                   md_uid = Types.Uid.internal_not_actually_unique;
-                 },
-                 Trec_not,
-                 Exported )
-             :: acc)
-           merged_signature [])
-  | None -> Error "Could not find build artifacts directory"
+  let* cmi_files = collect_cmi_files project_path in
+  let* signatures =
+    CCResult.map_l
+      (fun cmi_file ->
+        let+ signature, module_name = load_cmi cmi_file in
+        (module_name, signature))
+      cmi_files
+  in
+  let merged_signature =
+    List.fold_left
+      (fun acc (module_name, signature) ->
+        String_map.add module_name signature acc)
+      String_map.empty signatures
+  in
+  Ok
+    (String_map.fold
+       (fun module_name module_sig acc ->
+         Types.Sig_module
+           ( Ident.create_local module_name,
+             Mp_present,
+             {
+               md_type = Mty_signature module_sig;
+               md_attributes = [];
+               md_loc = Location.none;
+               md_uid = Types.Uid.internal_not_actually_unique;
+             },
+             Trec_not,
+             Exported )
+         :: acc)
+       merged_signature [])

--- a/lib/library.ml
+++ b/lib/library.ml
@@ -1,4 +1,4 @@
-let rec collect_cmi_files dir =
+let collect_cmi_files dir =
   let open CCResult.Infix in
   let* files =
     try Ok (Sys.readdir dir)
@@ -9,56 +9,63 @@ let rec collect_cmi_files dir =
     (fun acc_res file ->
       let* acc = acc_res in
       let path = Filename.concat dir file in
-      try
-        if Sys.is_directory path then
-          let+ subdir_files = collect_cmi_files path in
-          acc @ subdir_files
-        else if Filename.check_suffix file ".cmi" then Ok (path :: acc)
-        else Ok acc
-      with Sys_error e ->
-        Error (Printf.sprintf "Error processing %s: %s" path e))
+      if
+        Sys.file_exists path
+        && (not (Sys.is_directory path))
+        && Filename.check_suffix file ".cmi"
+      then Ok (path :: acc)
+      else Ok acc)
     (Ok []) files
 
 let load_cmi file_path =
   try
     let cmi_infos = Cmi_format.read_cmi file_path in
-    Ok cmi_infos.cmi_sign
+    Ok (cmi_infos.cmi_sign, cmi_infos.cmi_name)
   with e -> Error (Printexc.to_string e)
 
-let module_name_of_file file_path =
-  file_path |> Filename.basename |> Filename.remove_extension
-  |> String.capitalize_ascii
+let find_build_artifacts_dir project_path =
+  let build_dir = Filename.concat project_path "_build/default/lib" in
+  try
+    let dirs = Sys.readdir build_dir |> Array.to_list in
+    match List.find_opt (fun dir -> Filename.check_suffix dir ".objs") dirs with
+    | Some objs_dir ->
+        let full_objs_path = Filename.concat build_dir objs_dir in
+        Some (Filename.concat full_objs_path "byte")
+    | None -> None
+  with Sys_error _ -> None
 
 let load project_path =
   let open CCResult.Infix in
-  let* cmi_files = collect_cmi_files project_path in
-  let* signatures =
-    CCResult.map_l
-      (fun cmi_file ->
-        let module_name = module_name_of_file cmi_file in
-        let+ signature = load_cmi cmi_file in
-        (module_name, signature))
-      cmi_files
-  in
-  let merged_signature =
-    List.fold_left
-      (fun acc (module_name, signature) ->
-        String_map.add module_name signature acc)
-      String_map.empty signatures
-  in
-  Ok
-    (String_map.fold
-       (fun module_name module_sig acc ->
-         Types.Sig_module
-           ( Ident.create_local module_name,
-             Mp_present,
-             {
-               md_type = Mty_signature module_sig;
-               md_attributes = [];
-               md_loc = Location.none;
-               md_uid = Types.Uid.internal_not_actually_unique;
-             },
-             Trec_not,
-             Exported )
-         :: acc)
-       merged_signature [])
+  match find_build_artifacts_dir project_path with
+  | Some artifacts_dir ->
+      let* cmi_files = collect_cmi_files artifacts_dir in
+      let* signatures =
+        CCResult.map_l
+          (fun cmi_file ->
+            let+ signature, module_name = load_cmi cmi_file in
+            (module_name, signature))
+          cmi_files
+      in
+      let merged_signature =
+        List.fold_left
+          (fun acc (module_name, signature) ->
+            String_map.add module_name signature acc)
+          String_map.empty signatures
+      in
+      Ok
+        (String_map.fold
+           (fun module_name module_sig acc ->
+             Types.Sig_module
+               ( Ident.create_local module_name,
+                 Mp_present,
+                 {
+                   md_type = Mty_signature module_sig;
+                   md_attributes = [];
+                   md_loc = Location.none;
+                   md_uid = Types.Uid.internal_not_actually_unique;
+                 },
+                 Trec_not,
+                 Exported )
+             :: acc)
+           merged_signature [])
+  | None -> Error "Could not find build artifacts directory"

--- a/lib/library.ml
+++ b/lib/library.ml
@@ -1,0 +1,72 @@
+let rec collect_cmi_files dir =
+  try
+    let files = Sys.readdir dir in
+    Array.fold_left
+      (fun acc file ->
+        let path = Filename.concat dir file in
+        try
+          if Sys.is_directory path then acc @ collect_cmi_files path
+          else if Filename.check_suffix file ".cmi" then path :: acc
+          else acc
+        with Sys_error e ->
+          Printf.eprintf "Error processing %s: %s\n" path e;
+          acc)
+      [] files
+  with Sys_error e ->
+    Printf.eprintf "Error reading directory %s: %s\n" dir e;
+    []
+
+let load_cmi file_path =
+  try
+    let cmi_infos = Cmi_format.read_cmi file_path in
+    Ok cmi_infos.cmi_sign
+  with e -> Error (Printexc.to_string e)
+
+let module_name_of_file file_path =
+  file_path |> Filename.basename |> Filename.remove_extension
+  |> String.capitalize_ascii
+
+let find_build_artifacts project_path =
+  let build_dir = Filename.concat project_path "_build" in
+  if not (Sys.file_exists build_dir) then
+    Printf.eprintf "Build directory not found: %s\n" build_dir;
+  let default_dir = Filename.concat build_dir "default" in
+  let install_dir = Filename.concat build_dir "install/default/lib" in
+  if Sys.file_exists install_dir then collect_cmi_files install_dir
+  else if Sys.file_exists default_dir then collect_cmi_files default_dir
+  else collect_cmi_files build_dir
+
+let load project_path =
+  let cmi_files = find_build_artifacts project_path in
+  let signatures =
+    List.filter_map
+      (fun cmi_file ->
+        let module_name = module_name_of_file cmi_file in
+        match load_cmi cmi_file with
+        | Ok signature -> Some (module_name, signature)
+        | Error e ->
+            Printf.eprintf "Failed to load %s: %s\n" cmi_file e;
+            None)
+      cmi_files
+  in
+  let merged_signature =
+    List.fold_left
+      (fun acc (module_name, signature) ->
+        String_map.add module_name signature acc)
+      String_map.empty signatures
+  in
+  String_map.fold
+    (fun module_name module_sig acc ->
+      Types.Sig_module
+        ( Ident.create_local module_name,
+          Mp_present,
+          {
+            md_type = Mty_signature module_sig;
+            md_attributes = [];
+            md_loc = Location.none;
+            md_uid = Types.Uid.internal_not_actually_unique;
+          },
+          Trec_not,
+          Exported )
+      :: acc)
+    merged_signature []

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -1,1 +1,2 @@
+val load_cmi : string -> (Types.signature * string, string) result
 val load : string -> (Types.signature, string) result

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -1,1 +1,1 @@
-val load : string -> Types.signature
+val load : string -> (Types.signature, string) result

--- a/lib/library.mli
+++ b/lib/library.mli
@@ -1,0 +1,1 @@
+val load : string -> Types.signature

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -49,7 +49,6 @@ Run api-watcher on the two cmi files, there should be a difference
   diff module Add_type:
   
   +<unsupported change>
-  [1]
 
 ### A file with a removed type:
 
@@ -68,7 +67,6 @@ Run api-watcher on the two cmi files, there should be a difference
   diff module Remove_type:
   
   +<unsupported change>
-  [1]
 
 ### A file with a modified type:
 
@@ -88,7 +86,6 @@ Run api-watcher on the two cmi files, there should be a difference
   diff module Modify_type:
   
   +<unsupported change>
-  [1]
 
 ## Different .cmi files for value tests:
 
@@ -110,7 +107,6 @@ Run api-diff and check the output
   diff module Add_value:
   
   +val g : t -> t
-  [1]
 
 ### Removing a value:
 
@@ -128,7 +124,6 @@ Run api-diff and check the output
   diff module Remove_value:
   
   -val f : t -> string
-  [1]
 
 ### Modifying a value:
 
@@ -148,7 +143,6 @@ Run api-diff and check the output
   
   -val f : t -> string
   +val f : t -> t
-  [1]
 
 Here we generate a `.mli` file with a module:
 
@@ -183,7 +177,6 @@ Run api-diff and check the output
   diff module Add_module:
   
   +module N: sig val y : float end
-  [1]
 
 ### Removing a module:
 
@@ -200,7 +193,6 @@ Run api-diff and check the output
   diff module Remove_module:
   
   -module M: sig val x : int end
-  [1]
 
 ### Modifying a module:
 
@@ -219,7 +211,6 @@ Run api-diff and check the output
   
   -val x : int
   +val x : float
-  [1]
 
 Generate a new .mli file with values and submodules
   $ cat > orig_module.mli << EOF
@@ -267,7 +258,6 @@ Run api-diff and check the output
   -val g : int -> string
   +val g : int -> (string, string) result
   
-  [1]
 
 Create the first version of a simple project
   $ mkdir -p project_v1/lib
@@ -377,4 +367,3 @@ Run the api-diff tool on the two project versions
   diff module project_v2.Mylib__Utils:
   +val triple : int -> int
   
-  [1]

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -268,3 +268,113 @@ Run api-diff and check the output
   +val g : int -> (string, string) result
   
   [1]
+
+Create the first version of a simple project
+  $ mkdir -p project_v1/lib
+
+  $ cat > project_v1/dune-project <<EOF
+  > (lang dune 2.9)
+  > (name myproject)
+  > EOF
+
+  $ cat > project_v1/lib/dune <<EOF
+  > (library
+  >  (name mylib))
+  > EOF
+
+Create math.ml file with basic math functions and an Advanced module
+  $ cat > project_v1/lib/math.ml <<EOF
+  > let add x y = x + y
+  > let subtract x y = x - y
+  > module Advanced = struct
+  >   let square x = x * x
+  >   type shape = Square | Circle
+  > end
+  > EOF
+
+Create math.mli interface file
+  $ cat > project_v1/lib/math.mli <<EOF
+  > val add : int -> int -> int
+  > val subtract : int -> int -> int
+  > module Advanced : sig
+  >   val square : int -> int
+  >   type shape = Square | Circle
+  > end
+  > EOF
+
+Create utils.ml file with a double function
+  $ cat > project_v1/lib/utils.ml <<EOF
+  > let double x = x * 2
+  > EOF
+
+Create utils.mli interface file
+  $ cat > project_v1/lib/utils.mli <<EOF
+  > val double : int -> int
+  > EOF
+
+Build the first version
+  $ cd project_v1 && dune build && cd ..
+
+Create the second version of the same project with some changes
+  $ cp -r project_v1 project_v2
+
+Update math.ml in project_v2 with new functions and modifications
+  $ cat > project_v2/lib/math.ml <<EOF
+  > let add x y z = x + y + z
+  > let subtract x y = x - y
+  > let multiply x y = x * y
+  > module Advanced = struct
+  >   let square x = x * x
+  >   let cube x = x * x * x
+  >   type shape = Square | Circle | Triangle
+  > end
+  > module New_module = struct
+  >   let hello () = "Hello, World!"
+  > end
+  > EOF
+
+Update math.mli in project_v2 to reflect changes
+  $ cat > project_v2/lib/math.mli <<EOF
+  > val add : int -> int -> int -> int
+  > val subtract : int -> int -> int
+  > val multiply : int -> int -> int
+  > module Advanced : sig
+  >   val square : int -> int
+  >   val cube : int -> int
+  >   type shape = Square | Circle | Triangle
+  > end
+  > module New_module : sig
+  >   val hello : unit -> string
+  > end
+  > EOF
+
+Update utils.ml in project_v2 with a new triple function
+  $ cat > project_v2/lib/utils.ml <<EOF
+  > let double x = x * 2
+  > let triple x = x * 3
+  > EOF
+
+Update utils.mli in project_v2 to include the new triple function
+  $ cat > project_v2/lib/utils.mli <<EOF
+  > val double : int -> int
+  > val triple : int -> int
+  > EOF
+
+Build the second version
+  $ cd project_v2 && dune build && cd ..
+
+Run the api-diff tool on the two project versions
+  $ api-diff project_v1 project_v2
+  diff module project_v2.Mylib__Math:
+  -val add : int -> int -> int
+  +val add : int -> int -> int -> int
+  +val multiply : int -> int -> int
+  +module New_module: sig val hello : unit -> string end
+  
+  diff module project_v2.Mylib__Math.Advanced:
+  +val cube : int -> int
+  
+  diff module project_v2.Mylib__Utils:
+  +val triple : int -> int
+  
+  [1]

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -49,6 +49,7 @@ Run api-watcher on the two cmi files, there should be a difference
   diff module Add_type:
   
   +<unsupported change>
+  [1]
 
 ### A file with a removed type:
 
@@ -67,6 +68,7 @@ Run api-watcher on the two cmi files, there should be a difference
   diff module Remove_type:
   
   +<unsupported change>
+  [1]
 
 ### A file with a modified type:
 
@@ -86,6 +88,7 @@ Run api-watcher on the two cmi files, there should be a difference
   diff module Modify_type:
   
   +<unsupported change>
+  [1]
 
 ## Different .cmi files for value tests:
 
@@ -107,6 +110,7 @@ Run api-diff and check the output
   diff module Add_value:
   
   +val g : t -> t
+  [1]
 
 ### Removing a value:
 
@@ -124,6 +128,7 @@ Run api-diff and check the output
   diff module Remove_value:
   
   -val f : t -> string
+  [1]
 
 ### Modifying a value:
 
@@ -143,6 +148,7 @@ Run api-diff and check the output
   
   -val f : t -> string
   +val f : t -> t
+  [1]
 
 Here we generate a `.mli` file with a module:
 
@@ -177,6 +183,7 @@ Run api-diff and check the output
   diff module Add_module:
   
   +module N: sig val y : float end
+  [1]
 
 ### Removing a module:
 
@@ -193,6 +200,7 @@ Run api-diff and check the output
   diff module Remove_module:
   
   -module M: sig val x : int end
+  [1]
 
 ### Modifying a module:
 
@@ -211,6 +219,7 @@ Run api-diff and check the output
   
   -val x : int
   +val x : float
+  [1]
 
 Generate a new .mli file with values and submodules
   $ cat > orig_module.mli << EOF
@@ -258,6 +267,7 @@ Run api-diff and check the output
   -val g : int -> string
   +val g : int -> (string, string) result
   
+  [1]
 
 Create the first version of a simple project
   $ mkdir -p project_v1/lib
@@ -367,3 +377,4 @@ Run the api-diff tool on the two project versions
   diff module project_v2.Mylib__Utils:
   +val triple : int -> int
   
+  [1]

--- a/tests/api-diff/run.t
+++ b/tests/api-diff/run.t
@@ -354,7 +354,7 @@ Build the second version
   $ cd project_v2 && dune build && cd ..
 
 Run the api-diff tool on the two project versions
-  $ api-diff project_v1 project_v2
+  $ api-diff project_v1/_build/default/lib/.mylib.objs/byte project_v2/_build/default/lib/.mylib.objs/byte
   diff module project_v2.Mylib__Math:
   -val add : int -> int -> int
   +val add : int -> int -> int -> int


### PR DESCRIPTION
This PR makes the following changes:

- Added a function `dune_library_to_signature` which takes the path of a dune built library and extracts the signatures of all the different module files in that library, to build a "merged" signature of the entire library
- Modified the `api_diff.ml` to now either take two `.cmi` files (this uses the only the diffing implementation) OR two library paths (this uses the `dune_library_to_signature` and then the diffing implementation) as reference and current versions and then diff them
- Added a cram test which creates two versions (the second one with some modifications to test their diff) of a simple OCaml library with one main `math.ml` and another `utils.ml` file and uses `api-diff` command to create their text diff

**Note:**
The implementation of `dune_library_to_signature` requires that the project/library whose path is provided has been properly built and a `_build` folder is present for it in the path provided.